### PR TITLE
Gateway authorisation + aspects in passenger and driver services

### DIFF
--- a/driver-service/src/main/java/com/example/driverservice/configuration/aspect/CrossUserDataAccessCheckAspect.java
+++ b/driver-service/src/main/java/com/example/driverservice/configuration/aspect/CrossUserDataAccessCheckAspect.java
@@ -1,0 +1,61 @@
+package com.example.driverservice.configuration.aspect;
+
+import static com.example.driverservice.utility.constants.InternationalizationExceptionPropertyVariablesConstants.CROSS_USER_ACCESS_FORBIDDEN_EXCEPTION;
+import static com.example.driverservice.utility.constants.InternationalizationExceptionPropertyVariablesConstants.CROSS_USER_ACCESS_HEADER_SKIPPED_EXCEPTION;
+import static com.example.driverservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_FORBIDDEN;
+import static com.example.driverservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_HEADER_ID_SKIPPED;
+import static com.example.driverservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_PATH_ID_SKIPPED;
+import static com.example.driverservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_PROVIDED;
+import static com.example.driverservice.utility.constants.UtilConstants.PASSENGER_ID_PATH_NAME;
+import static com.example.driverservice.utility.constants.UtilConstants.USER_ID_HEADER_NAME;
+
+import com.example.driverservice.exception.custom.ResourceSecurityViolationException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+
+@Component
+@Slf4j
+@Aspect
+public class CrossUserDataAccessCheckAspect {
+
+    @Before("within(com.example.driverservice.controller.DriverController)")
+    public void logRequestAndResponse() {
+        HttpServletRequest request = getCurrentHttpRequest();
+        String pathId = extractIdFromRequest(request);
+        if (pathId == null) {
+            log.info(CROSS_USER_DATA_ACCESS_PATH_ID_SKIPPED);
+            return;
+        }
+        String headerId = request.getHeader(USER_ID_HEADER_NAME);
+        if (headerId == null) {
+            log.warn(CROSS_USER_DATA_ACCESS_HEADER_ID_SKIPPED);
+            throw new ResourceSecurityViolationException(CROSS_USER_ACCESS_HEADER_SKIPPED_EXCEPTION);
+        } else if (!headerId.equals(pathId)) {
+            log.warn(CROSS_USER_DATA_ACCESS_FORBIDDEN, headerId, pathId);
+            throw new ResourceSecurityViolationException(CROSS_USER_ACCESS_FORBIDDEN_EXCEPTION);
+        }
+        log.info(CROSS_USER_DATA_ACCESS_PROVIDED, headerId);
+    }
+
+    private HttpServletRequest getCurrentHttpRequest() {
+        return ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder
+                .getRequestAttributes()))
+                .getRequest();
+    }
+
+    @SuppressWarnings("unchecked")
+    public String extractIdFromRequest(HttpServletRequest request) {
+        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(
+                HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        return pathVariables.get(PASSENGER_ID_PATH_NAME);
+    }
+
+}

--- a/driver-service/src/main/java/com/example/driverservice/configuration/aspect/HttpLoggingAspect.java
+++ b/driver-service/src/main/java/com/example/driverservice/configuration/aspect/HttpLoggingAspect.java
@@ -4,7 +4,7 @@ import static com.example.driverservice.utility.constants.InternationalizationEx
 import static com.example.driverservice.utility.constants.LogMessagesTemplate.EXCEPTION_RESPONSE_LOG_TEMPLATE;
 import static com.example.driverservice.utility.constants.LogMessagesTemplate.REQUEST_LOG_TEMPLATE;
 import static com.example.driverservice.utility.constants.LogMessagesTemplate.RESPONSE_LOG_TEMPLATE;
-import static com.example.driverservice.utility.constants.LogMessagesTemplate.SERIALISATION_DELIMITER;
+import static com.example.driverservice.utility.constants.UtilConstants.SERIALISATION_DELIMITER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -43,7 +43,7 @@ public class HttpLoggingAspect {
         ResponseEntity<?> response = (ResponseEntity<?>) joinPoint.proceed();
         long duration = System.currentTimeMillis() - startTime;
 
-        String responseBody = serializeToJson(response);
+        String responseBody = serializeToJson(response.getBody());
         log.info(RESPONSE_LOG_TEMPLATE,
                 request.getMethod(),
                 response.getStatusCode(),
@@ -57,13 +57,11 @@ public class HttpLoggingAspect {
             pointcut = "@within(org.springframework.web.bind.annotation.RestControllerAdvice))",
             returning = "result"
     )
-    public Object logRequestAndResponseForExceptionHandler(
-            Object result
-    ) {
+    public Object logRequestAndResponseForExceptionHandler(Object result) {
         HttpServletRequest httpRequest = getCurrentHttpRequest();
         ResponseEntity<?> response = (ResponseEntity<?>) result;
-        String responseBody = serializeToJson(response);
-        log.info(EXCEPTION_RESPONSE_LOG_TEMPLATE,
+        String responseBody = serializeToJson(response.getBody());
+        log.warn(EXCEPTION_RESPONSE_LOG_TEMPLATE,
                 httpRequest.getMethod(),
                 response.getStatusCode(),
                 httpRequest.getRequestURI(),

--- a/driver-service/src/main/java/com/example/driverservice/exception/GlobalExceptionHandler.java
+++ b/driver-service/src/main/java/com/example/driverservice/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.example.driverservice.dto.exception.ExceptionHandlerResponse;
 import com.example.driverservice.exception.custom.DbModificationAttemptException;
 import com.example.driverservice.exception.custom.EntityNotFoundException;
 import com.example.driverservice.exception.custom.IllegalEnumArgumentException;
+import com.example.driverservice.exception.custom.ResourceSecurityViolationException;
 import jakarta.validation.ConstraintViolationException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,13 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({
+        ResourceSecurityViolationException.class
+    })
+    public ResponseEntity<ExceptionHandlerResponse> handleForbiddenException(Exception e) {
+        return getExceptionResponse(e, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler({
         Exception.class
     })
     public ResponseEntity<ExceptionHandlerResponse> handleOtherExceptions(Exception e) {
@@ -49,10 +57,11 @@ public class GlobalExceptionHandler {
     }
 
     private ResponseEntity<ExceptionHandlerResponse> getExceptionResponse(Exception e, HttpStatus httpStatus) {
-        return new ResponseEntity<>(new ExceptionHandlerResponse(
-                httpStatus.value(),
-                getExceptionMessage(e),
-                LocalDateTime.now()),
+        return new ResponseEntity<>(
+                new ExceptionHandlerResponse(
+                        httpStatus.value(),
+                        getExceptionMessage(e),
+                        LocalDateTime.now()),
                 httpStatus
         );
     }

--- a/driver-service/src/main/java/com/example/driverservice/exception/custom/ResourceSecurityViolationException.java
+++ b/driver-service/src/main/java/com/example/driverservice/exception/custom/ResourceSecurityViolationException.java
@@ -1,0 +1,11 @@
+package com.example.driverservice.exception.custom;
+
+import com.example.driverservice.exception.MessageSourceException;
+
+public class ResourceSecurityViolationException extends MessageSourceException {
+
+    public ResourceSecurityViolationException(String messageKey, String... args) {
+        super(messageKey, args);
+    }
+
+}

--- a/driver-service/src/main/java/com/example/driverservice/utility/constants/InternationalizationExceptionPropertyVariablesConstants.java
+++ b/driver-service/src/main/java/com/example/driverservice/utility/constants/InternationalizationExceptionPropertyVariablesConstants.java
@@ -13,5 +13,7 @@ public class InternationalizationExceptionPropertyVariablesConstants {
     public static final String INVALID_ATTEMPT_CHANGE_DRIVER = "exception.invalid.attempt.change.driver";
     public static final String INVALID_ATTEMPT_CHANGE_CAR = "exception.invalid.attempt.change.car";
     public static final String INTERNAL_SERVICE_ERROR = "exception.internal.server.error";
+    public static final String CROSS_USER_ACCESS_HEADER_SKIPPED_EXCEPTION = "exception.cross.user.access.header.skipped";
+    public static final String CROSS_USER_ACCESS_FORBIDDEN_EXCEPTION = "exception.cross.user.access.forbidden";
 
 }

--- a/driver-service/src/main/java/com/example/driverservice/utility/constants/LogMessagesTemplate.java
+++ b/driver-service/src/main/java/com/example/driverservice/utility/constants/LogMessagesTemplate.java
@@ -6,12 +6,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class LogMessagesTemplate {
 
-    public static final String REQUEST_LOG_TEMPLATE = "Http-{} request | URI: {} | Request args: {}";
+    public static final String REQUEST_LOG_TEMPLATE =
+            "Http-{} request | URI: {} | Request body: {}";
     public static final String RESPONSE_LOG_TEMPLATE =
-            "Http-{} response | Status code: {} | URI: {} | Response args: {} | Duration: {} ms";
+            "Http-{} response | Status code: {} | URI: {} | Response body: {} | Duration: {} ms";
     public static final String EXCEPTION_RESPONSE_LOG_TEMPLATE =
-            "Http-{} exception response | Status code: {} | URI: {} | Response args: {}";
-    public static final String KAFKA_LISTENER_EVENT_LOG_TEMPLATE = "KafkaListener received event | Event: {}";
-    public static final String SERIALISATION_DELIMITER = ", ";
+            "Http-{} exception response | Status code: {} | URI: {} | Response body: {}";
+    public static final String KAFKA_LISTENER_EVENT_LOG_TEMPLATE =
+            "KafkaListener received event | Event: {}";
+    public static final String CROSS_USER_DATA_ACCESS_PATH_ID_SKIPPED =
+            "Cross user data change attempt: path id absences, check skipped.";
+    public static final String CROSS_USER_DATA_ACCESS_HEADER_ID_SKIPPED =
+            "Cross user data change attempt: header X-User-Id absences in request.";
+    public static final String CROSS_USER_DATA_ACCESS_FORBIDDEN =
+            "Cross user data access attempt: access forbidden, user ({}) tried to get access to user ({})";
+    public static final String CROSS_USER_DATA_ACCESS_PROVIDED =
+            "Cross user data access attempt: access provided to user ({}).";
 
 }

--- a/driver-service/src/main/java/com/example/driverservice/utility/constants/UtilConstants.java
+++ b/driver-service/src/main/java/com/example/driverservice/utility/constants/UtilConstants.java
@@ -1,0 +1,13 @@
+package com.example.driverservice.utility.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UtilConstants {
+
+    public static final String SERIALISATION_DELIMITER = ", ";
+    public static final String USER_ID_HEADER_NAME = "X-User-Id";
+    public static final String PASSENGER_ID_PATH_NAME = "id";
+
+}

--- a/driver-service/src/main/resources/messages_en.properties
+++ b/driver-service/src/main/resources/messages_en.properties
@@ -30,3 +30,5 @@ exception.invalid.attempt.change.car=Invalid attempt to {0} car ({1})
 validate.method.parameter.id.negative=ID must be a positive number
 exception.invalid.serialisation.attempt=Invalid attempt to serialise object to JSON
 exception.internal.server.error=Internal server error: {0}
+exception.cross.user.access.forbidden=User tries to access another user's data
+exception.cross.user.access.header.skipped=Header X-User-Id absences in request

--- a/driver-service/src/main/resources/messages_ru.properties
+++ b/driver-service/src/main/resources/messages_ru.properties
@@ -30,3 +30,5 @@ exception.invalid.attempt.change.car=Неудачная попытка сове�
 validate.method.parameter.id.negative=ID должно быть неотрицательным числом
 exception.invalid.serialisation.attempt=Неудачная попытка сериализовать объект JSON
 exception.internal.server.error=Внутренняя ошибка сервера: {0}
+exception.cross.user.access.forbidden=Пользователь пытается получить доступ к другому пользователю
+exception.cross.user.access.header.skipped=Заголовок X-User-Id отсутствует в запросе

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -24,6 +24,7 @@
         <micrometer-tracing-bom.version>1.4.3</micrometer-tracing-bom.version>
         <opentelemetry-bom.version>1.43.0</opentelemetry-bom.version>
 
+        <jjwt.version>0.12.6</jjwt.version>
         <springdoc-openapi-starter.version>2.8.3</springdoc-openapi-starter.version>
         <loki.version>1.6.0</loki.version>
         <janino.version>3.1.12</janino.version>
@@ -96,10 +97,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>${jjwt.version}</version>
         </dependency>
 
         <dependency>

--- a/gateway-service/src/main/java/com/example/gatewayservice/configuration/SwaggerConfig.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/configuration/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.example.gatewayservice.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private SecurityScheme createAPIKeyScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .bearerFormat("JWT")
+                .scheme("bearer");
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement()
+                        .addList("Bearer Authentication"))
+                .components(new Components()
+                        .addSecuritySchemes("Bearer Authentication", createAPIKeyScheme()));
+    }
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/configuration/WebSecurityConfig.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/configuration/WebSecurityConfig.java
@@ -1,0 +1,63 @@
+package com.example.gatewayservice.configuration;
+
+import com.example.gatewayservice.configuration.jwt.JwtAuthConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers(
+                                "/api/v1/users/login",
+                                "/api/v1/users/refresh",
+                                "/api/v1/users/passenger",
+                                "/api/v1/users/driver",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/swagger-resources/**",
+                                "/api-docs/**",
+                                "/webjars/**",
+                                "/actuator/**"
+                        ).permitAll()
+                        .pathMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/passengers"
+                        ).hasAnyRole("passenger", "admin")
+                        .pathMatchers(
+                                "/api/v1/passengers/**"
+                        ).hasAnyRole("passenger")
+                        .pathMatchers(
+                                HttpMethod.GET,
+                                "/api/v1/drivers",
+                                "/api/v1/cars"
+                        ).hasAnyRole("driver", "admin")
+                        .pathMatchers(
+                                "/api/v1/drivers/**",
+                                "/api/v1/cars/**"
+                        ).hasAnyRole("driver")
+                        .pathMatchers(
+                                "/api/v1/users/logout",
+                                "/api/v1/rates/**",
+                                "/api/v1/rides/**"
+                        ).hasAnyRole("passenger", "driver", "admin")
+                        .anyExchange().hasRole("admin"))
+                .oauth2ResourceServer(oAuth2ResourceServerSpec -> oAuth2ResourceServerSpec
+                        .jwt(jwt -> jwt
+                                .jwtAuthenticationConverter(
+                                        new ReactiveJwtAuthenticationConverterAdapter(
+                                                new JwtAuthConverter()))))
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .build();
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/configuration/aspect/HttpLoggingAspect.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/configuration/aspect/HttpLoggingAspect.java
@@ -23,12 +23,10 @@ public class HttpLoggingAspect {
             pointcut = "@within(org.springframework.web.bind.annotation.RestControllerAdvice))",
             returning = "result"
     )
-    public Object logRequestAndResponseForExceptionHandler(
-            Object result
-    ) {
+    public Object logRequestAndResponseForExceptionHandler(Object result) {
         ResponseEntity<?> response = (ResponseEntity<?>) result;
-        String responseBody = serializeToJson(response);
-        log.info(EXCEPTION_RESPONSE_LOG_TEMPLATE,
+        String responseBody = serializeToJson(response.getBody());
+        log.warn(EXCEPTION_RESPONSE_LOG_TEMPLATE,
                 response.getStatusCode(),
                 responseBody);
         return response;
@@ -41,7 +39,7 @@ public class HttpLoggingAspect {
         try {
             return jsonMapper.writeValueAsString(object);
         } catch (Exception e) {
-            log.error(INVALID_SERIALISATION_ATTEMPT, e);
+            log.warn(INVALID_SERIALISATION_ATTEMPT, e);
             return INVALID_SERIALISATION_ATTEMPT;
         }
     }

--- a/gateway-service/src/main/java/com/example/gatewayservice/configuration/filter/AddAuthHeaderGlobalFilter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/configuration/filter/AddAuthHeaderGlobalFilter.java
@@ -1,0 +1,39 @@
+package com.example.gatewayservice.configuration.filter;
+
+import static com.example.gatewayservice.utility.constants.LogMessagesTemplate.USER_ID_HEADER_ADDED;
+import static com.example.gatewayservice.utility.constants.LogMessagesTemplate.USER_ID_HEADER_SKIPPED;
+import static com.example.gatewayservice.utility.constants.UtilConstants.USER_ID_HEADER_NAME;
+
+import com.example.gatewayservice.configuration.jwt.JwtUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AddAuthHeaderGlobalFilter implements GlobalFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String subject = JwtUtils.extractSubjectFromRequest(exchange.getRequest());
+        if (subject != null) {
+            ServerHttpRequest modifiedRequest = exchange
+                    .getRequest()
+                    .mutate()
+                    .header(USER_ID_HEADER_NAME, subject)
+                    .build();
+
+            log.info(USER_ID_HEADER_ADDED, subject);
+            return chain.filter(exchange.mutate().request(modifiedRequest).build());
+        }
+        log.info(USER_ID_HEADER_SKIPPED);
+        return chain.filter(exchange);
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/configuration/jwt/JwtAuthConverter.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/configuration/jwt/JwtAuthConverter.java
@@ -1,0 +1,47 @@
+package com.example.gatewayservice.configuration.jwt;
+
+import static com.example.gatewayservice.utility.constants.UtilConstants.REALM_ACCESS_CLAIM;
+import static com.example.gatewayservice.utility.constants.UtilConstants.REALM_ACCESS_ROLES;
+import static com.example.gatewayservice.utility.constants.UtilConstants.ROLE_PREFIX;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    @Override
+    @NonNull
+    public AbstractAuthenticationToken convert(@NonNull Jwt jwt) {
+        Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
+        return new JwtAuthenticationToken(jwt, authorities);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaim(REALM_ACCESS_CLAIM);
+        if (realmAccess == null || realmAccess.get(REALM_ACCESS_ROLES) == null) {
+            return Collections.emptyList();
+        }
+        Collection<String> roles = (Collection<String>) realmAccess.get(REALM_ACCESS_ROLES);
+        return roles.stream()
+                .map(role -> ROLE_PREFIX + role)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/configuration/jwt/JwtUtils.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/configuration/jwt/JwtUtils.java
@@ -1,0 +1,40 @@
+package com.example.gatewayservice.configuration.jwt;
+
+import static com.example.gatewayservice.utility.constants.ExceptionConstants.INVALID_SUBJECT_EXTRACTION;
+
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtils {
+
+    public static String extractSubjectFromRequest(ServerHttpRequest request) {
+        String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return null;
+        }
+        String jwtToken = authHeader.substring(7);
+
+        String[] jwtParts = jwtToken.split("\\.");
+        if (jwtParts.length != 3) {
+            throw new IllegalArgumentException(INVALID_SUBJECT_EXTRACTION);
+        }
+        String payloadJson = new String(Base64.getUrlDecoder().decode(jwtParts[1]));
+        return extractFieldFromJson(payloadJson);
+    }
+
+    private static String extractFieldFromJson(String json) {
+        int fieldIndex = json.indexOf("\"sub\":");
+        if (fieldIndex == -1) {
+            return null;
+        }
+        int valueStart = json.indexOf("\"", fieldIndex + "sub".length() + 3) + 1;
+        int valueEnd = json.indexOf("\"", valueStart);
+        return json.substring(valueStart, valueEnd);
+    }
+
+}

--- a/gateway-service/src/main/java/com/example/gatewayservice/utility/constants/ExceptionConstants.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/utility/constants/ExceptionConstants.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public final class ExceptionConstants {
 
     public static final String INVALID_SERIALISATION_ATTEMPT = "exception.invalid.serialisation.attempt";
+    public static final String INVALID_SUBJECT_EXTRACTION = "exception.invalid.subject.extraction";
     public static final String SERVICE_PATH_NOT_FOUND = "exception.service.not-found";
     public static final String EXTERNAL_SERVICE_UNAVAILABLE = "exception.external-service.unavailable";
     public static final String INTERNAL_SERVICE_ERROR = "exception.internal-service.error";

--- a/gateway-service/src/main/java/com/example/gatewayservice/utility/constants/LogMessagesTemplate.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/utility/constants/LogMessagesTemplate.java
@@ -7,6 +7,10 @@ import lombok.NoArgsConstructor;
 public final class LogMessagesTemplate {
 
     public static final String EXCEPTION_RESPONSE_LOG_TEMPLATE =
-            "Gateway exception response | Status code: {} | Response args: {}";
+            "Gateway exception response | Status code: {} | Response body: {}";
+    public static final String USER_ID_HEADER_ADDED =
+            "Add user id header GlobalFilter: header added with value ({})";
+    public static final String USER_ID_HEADER_SKIPPED =
+            "Add user id header GlobalFilter: header not added";
 
 }

--- a/gateway-service/src/main/java/com/example/gatewayservice/utility/constants/UtilConstants.java
+++ b/gateway-service/src/main/java/com/example/gatewayservice/utility/constants/UtilConstants.java
@@ -1,0 +1,14 @@
+package com.example.gatewayservice.utility.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UtilConstants {
+
+    public static final String USER_ID_HEADER_NAME = "X-User-Id";
+    public static final String REALM_ACCESS_CLAIM = "realm_access";
+    public static final String REALM_ACCESS_ROLES = "roles";
+    public static final String ROLE_PREFIX = "ROLE_";
+
+}

--- a/gateway-service/src/main/resources/application.yaml
+++ b/gateway-service/src/main/resources/application.yaml
@@ -1,9 +1,15 @@
 server:
-  port: 8080
+  port: 9090
 
 spring:
   application:
     name: gateway-service
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: "http://${keycloak.domain}/realms/${keycloak.realm}"
+          jwk-set-uri: "http://${keycloak.domain}/realms/${keycloak.realm}/protocol/openid-connect/certs"
   cloud:
     gateway:
       routes:
@@ -23,6 +29,20 @@ spring:
           uri: lb://rates-service
           predicates:
             - Path=/api/v1/rates/**
+        - id: auth-service
+          uri: lb://auth-service
+          predicates:
+            - Path=/api/v1/users/**
+
+keycloak:
+  realm: ${KEYCLOAK_REALM:cab-aggregator}
+  domain: ${KEYCLOAK_DOMAIN:localhost:8080}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
 
 eureka:
   client:

--- a/gateway-service/src/main/resources/messages_en.properties
+++ b/gateway-service/src/main/resources/messages_en.properties
@@ -2,3 +2,4 @@ exception.invalid.serialisation.attempt=Invalid attempt to serialise object to J
 exception.service.not-found=Service with such path wasn't found: {0}
 exception.external-service.unavailable=External service is unavailable at the moment: {0}
 exception.internal-service.error=Internal service error: {0}
+exception.invalid.subject.extraction=Invalid JWT format

--- a/gateway-service/src/main/resources/messages_ru.properties
+++ b/gateway-service/src/main/resources/messages_ru.properties
@@ -2,3 +2,4 @@ exception.invalid.serialisation.attempt=Неудачная попытка сер
 exception.service.not-found=Сервис с таким путем не был найден: {0}
 exception.external-service.unavailable=Внешний сервис не доступен в данный момент: {0}
 exception.internal-service.error=Внутренняя ошибка сервиса: {0}
+exception.invalid.subject.extraction=Неверный формат JWT

--- a/passenger-service/pom.xml
+++ b/passenger-service/pom.xml
@@ -239,11 +239,6 @@
             <artifactId>datasource-micrometer-spring-boot</artifactId>
             <version>${datasource-micrometer.version}</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>io.opentelemetry.instrumentation</groupId>-->
-<!--            <artifactId>opentelemetry-kafka-clients-2.6</artifactId>-->
-<!--            <version>2.14.0-alpha</version>-->
-<!--        </dependency>-->
     </dependencies>
 
     <build>

--- a/passenger-service/src/main/java/com/example/passengerservice/configuration/aspect/CrossUserDataAccessCheckAspect.java
+++ b/passenger-service/src/main/java/com/example/passengerservice/configuration/aspect/CrossUserDataAccessCheckAspect.java
@@ -1,0 +1,61 @@
+package com.example.passengerservice.configuration.aspect;
+
+import static com.example.passengerservice.utility.constants.InternationalizationExceptionPropertyVariablesConstants.CROSS_USER_ACCESS_FORBIDDEN_EXCEPTION;
+import static com.example.passengerservice.utility.constants.InternationalizationExceptionPropertyVariablesConstants.CROSS_USER_ACCESS_HEADER_SKIPPED_EXCEPTION;
+import static com.example.passengerservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_FORBIDDEN;
+import static com.example.passengerservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_HEADER_ID_SKIPPED;
+import static com.example.passengerservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_PATH_ID_SKIPPED;
+import static com.example.passengerservice.utility.constants.LogMessagesTemplate.CROSS_USER_DATA_ACCESS_PROVIDED;
+import static com.example.passengerservice.utility.constants.UtilConstants.PASSENGER_ID_PATH_NAME;
+import static com.example.passengerservice.utility.constants.UtilConstants.USER_ID_HEADER_NAME;
+
+import com.example.passengerservice.exception.custom.ResourceSecurityViolationException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+
+@Component
+@Slf4j
+@Aspect
+public class CrossUserDataAccessCheckAspect {
+
+    @Before("@within(org.springframework.web.bind.annotation.RestController)")
+    public void logRequestAndResponse() {
+        HttpServletRequest request = getCurrentHttpRequest();
+        String pathId = extractIdFromRequest(request);
+        if (pathId == null) {
+            log.info(CROSS_USER_DATA_ACCESS_PATH_ID_SKIPPED);
+            return;
+        }
+        String headerId = request.getHeader(USER_ID_HEADER_NAME);
+        if (headerId == null) {
+            log.warn(CROSS_USER_DATA_ACCESS_HEADER_ID_SKIPPED);
+            throw new ResourceSecurityViolationException(CROSS_USER_ACCESS_HEADER_SKIPPED_EXCEPTION);
+        } else if (!headerId.equals(pathId)) {
+            log.warn(CROSS_USER_DATA_ACCESS_FORBIDDEN, headerId, pathId);
+            throw new ResourceSecurityViolationException(CROSS_USER_ACCESS_FORBIDDEN_EXCEPTION);
+        }
+        log.info(CROSS_USER_DATA_ACCESS_PROVIDED, headerId);
+    }
+
+    private HttpServletRequest getCurrentHttpRequest() {
+        return ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder
+                .getRequestAttributes()))
+                .getRequest();
+    }
+
+    @SuppressWarnings("unchecked")
+    public String extractIdFromRequest(HttpServletRequest request) {
+        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(
+                HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        return pathVariables.get(PASSENGER_ID_PATH_NAME);
+    }
+
+}

--- a/passenger-service/src/main/java/com/example/passengerservice/configuration/aspect/HttpLoggingAspect.java
+++ b/passenger-service/src/main/java/com/example/passengerservice/configuration/aspect/HttpLoggingAspect.java
@@ -4,7 +4,7 @@ import static com.example.passengerservice.utility.constants.Internationalizatio
 import static com.example.passengerservice.utility.constants.LogMessagesTemplate.EXCEPTION_RESPONSE_LOG_TEMPLATE;
 import static com.example.passengerservice.utility.constants.LogMessagesTemplate.REQUEST_LOG_TEMPLATE;
 import static com.example.passengerservice.utility.constants.LogMessagesTemplate.RESPONSE_LOG_TEMPLATE;
-import static com.example.passengerservice.utility.constants.LogMessagesTemplate.SERIALISATION_DELIMITER;
+import static com.example.passengerservice.utility.constants.UtilConstants.SERIALISATION_DELIMITER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -43,7 +43,7 @@ public class HttpLoggingAspect {
         ResponseEntity<?> response = (ResponseEntity<?>) joinPoint.proceed();
         long duration = System.currentTimeMillis() - startTime;
 
-        String responseBody = serializeToJson(response);
+        String responseBody = serializeToJson(response.getBody());
         log.info(RESPONSE_LOG_TEMPLATE,
                 request.getMethod(),
                 response.getStatusCode(),
@@ -57,13 +57,11 @@ public class HttpLoggingAspect {
             pointcut = "@within(org.springframework.web.bind.annotation.RestControllerAdvice))",
             returning = "result"
     )
-    public Object logRequestAndResponseForExceptionHandler(
-            Object result
-    ) {
+    public Object logRequestAndResponseForExceptionHandler(Object result) {
         HttpServletRequest httpRequest = getCurrentHttpRequest();
         ResponseEntity<?> response = (ResponseEntity<?>) result;
-        String responseBody = serializeToJson(response);
-        log.info(EXCEPTION_RESPONSE_LOG_TEMPLATE,
+        String responseBody = serializeToJson(response.getBody());
+        log.warn(EXCEPTION_RESPONSE_LOG_TEMPLATE,
                 httpRequest.getMethod(),
                 response.getStatusCode(),
                 httpRequest.getRequestURI(),

--- a/passenger-service/src/main/java/com/example/passengerservice/exception/GlobalExceptionHandler.java
+++ b/passenger-service/src/main/java/com/example/passengerservice/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import static com.example.passengerservice.utility.constants.Internationalizatio
 import com.example.passengerservice.dto.exception.ExceptionHandlerResponse;
 import com.example.passengerservice.exception.custom.DbModificationAttemptException;
 import com.example.passengerservice.exception.custom.PassengerNotFoundException;
+import com.example.passengerservice.exception.custom.ResourceSecurityViolationException;
 import jakarta.validation.ConstraintViolationException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,13 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({
+        ResourceSecurityViolationException.class
+    })
+    public ResponseEntity<ExceptionHandlerResponse> handleForbiddenException(Exception e) {
+        return getExceptionResponse(e, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler({
         Exception.class
     })
     public ResponseEntity<ExceptionHandlerResponse> handleOtherExceptions(Exception e) {
@@ -47,7 +55,8 @@ public class GlobalExceptionHandler {
     }
 
     private ResponseEntity<ExceptionHandlerResponse> getExceptionResponse(Exception e, HttpStatus httpStatus) {
-        return new ResponseEntity<>(new ExceptionHandlerResponse(
+        return new ResponseEntity<>(
+                new ExceptionHandlerResponse(
                     httpStatus.value(),
                     getExceptionMessage(e),
                     LocalDateTime.now()),

--- a/passenger-service/src/main/java/com/example/passengerservice/exception/custom/ResourceSecurityViolationException.java
+++ b/passenger-service/src/main/java/com/example/passengerservice/exception/custom/ResourceSecurityViolationException.java
@@ -1,0 +1,11 @@
+package com.example.passengerservice.exception.custom;
+
+import com.example.passengerservice.exception.MessageSourceException;
+
+public class ResourceSecurityViolationException extends MessageSourceException {
+
+    public ResourceSecurityViolationException(String messageKey, String... args) {
+        super(messageKey, args);
+    }
+
+}

--- a/passenger-service/src/main/java/com/example/passengerservice/utility/constants/InternationalizationExceptionPropertyVariablesConstants.java
+++ b/passenger-service/src/main/java/com/example/passengerservice/utility/constants/InternationalizationExceptionPropertyVariablesConstants.java
@@ -10,5 +10,7 @@ public final class InternationalizationExceptionPropertyVariablesConstants {
     public static final String PASSENGER_NOT_FOUND = "exception.passenger.not.found";
     public static final String INVALID_ATTEMPT_CHANGE_PASSENGER = "exception.invalid.attempt.change.passenger";
     public static final String INTERNAL_SERVICE_ERROR = "exception.internal.server.error";
+    public static final String CROSS_USER_ACCESS_HEADER_SKIPPED_EXCEPTION = "exception.cross.user.access.header.skipped";
+    public static final String CROSS_USER_ACCESS_FORBIDDEN_EXCEPTION = "exception.cross.user.access.forbidden";
 
 }

--- a/passenger-service/src/main/java/com/example/passengerservice/utility/constants/LogMessagesTemplate.java
+++ b/passenger-service/src/main/java/com/example/passengerservice/utility/constants/LogMessagesTemplate.java
@@ -6,13 +6,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class LogMessagesTemplate {
 
-    public static final String REQUEST_LOG_TEMPLATE = "Http-{} request | URI: {} | Request args: {}";
+    public static final String REQUEST_LOG_TEMPLATE =
+            "Http-{} request | URI: {} | Request body: {}";
     public static final String RESPONSE_LOG_TEMPLATE =
-            "Http-{} response | Status code: {} | URI: {} | Response args: {} | Duration: {} ms";
+            "Http-{} response | Status code: {} | URI: {} | Response body: {} | Duration: {} ms";
     public static final String EXCEPTION_RESPONSE_LOG_TEMPLATE =
-            "Http-{} exception response | Status code: {} | URI: {} | Response args: {}";
+            "Http-{} exception response | Status code: {} | URI: {} | Response body: {}";
     public static final String KAFKA_LISTENER_EVENT_LOG_TEMPLATE =
             "KafkaListener received event (key={}, partition={}) | Event: {}";
-    public static final String SERIALISATION_DELIMITER = ", ";
+    public static final String CROSS_USER_DATA_ACCESS_PATH_ID_SKIPPED =
+            "Cross user data change attempt: path id absences, check skipped.";
+    public static final String CROSS_USER_DATA_ACCESS_HEADER_ID_SKIPPED =
+            "Cross user data change attempt: header X-User-Id absences in request.";
+    public static final String CROSS_USER_DATA_ACCESS_FORBIDDEN =
+            "Cross user data access attempt: access forbidden, user ({}) tried to get access to user ({})";
+    public static final String CROSS_USER_DATA_ACCESS_PROVIDED =
+            "Cross user data access attempt: access provided to user ({}).";
 
 }

--- a/passenger-service/src/main/java/com/example/passengerservice/utility/constants/UtilConstants.java
+++ b/passenger-service/src/main/java/com/example/passengerservice/utility/constants/UtilConstants.java
@@ -1,0 +1,13 @@
+package com.example.passengerservice.utility.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UtilConstants {
+
+    public static final String SERIALISATION_DELIMITER = ", ";
+    public static final String USER_ID_HEADER_NAME = "X-User-Id";
+    public static final String PASSENGER_ID_PATH_NAME = "id";
+
+}

--- a/passenger-service/src/main/resources/messages_en.properties
+++ b/passenger-service/src/main/resources/messages_en.properties
@@ -12,3 +12,5 @@ exception.passenger.not.found=Passenger with ID ({0}) not found
 exception.invalid.attempt.change.passenger=Invalid attempt to {0} passenger ({1})
 exception.invalid.serialisation.attempt=Invalid attempt to serialise object to JSON
 exception.internal.server.error=Internal server error: {0}
+exception.cross.user.access.forbidden=User tries to access another user's data
+exception.cross.user.access.header.skipped=Header X-User-Id absences in request

--- a/passenger-service/src/main/resources/messages_ru.properties
+++ b/passenger-service/src/main/resources/messages_ru.properties
@@ -12,3 +12,5 @@ exception.passenger.not.found=Пассажир с ID ({0}) не найден
 exception.invalid.attempt.change.passenger=Неудачная попытка совершить операцию ({0}) с пассажиром ({1})
 exception.invalid.serialisation.attempt=Неудачная попытка сериализовать объект JSON
 exception.internal.server.error=Внутренняя ошибка сервера: {0}
+exception.cross.user.access.forbidden=Пользователь пытается получить доступ к другому пользователю
+exception.cross.user.access.header.skipped=Заголовок X-User-Id отсутствует в запросе

--- a/rates-service/src/main/java/com/example/ratesservice/configuration/aspect/HttpLoggingAspect.java
+++ b/rates-service/src/main/java/com/example/ratesservice/configuration/aspect/HttpLoggingAspect.java
@@ -44,7 +44,7 @@ public class HttpLoggingAspect {
         ResponseEntity<?> response = (ResponseEntity<?>) joinPoint.proceed();
         long duration = System.currentTimeMillis() - startTime;
 
-        String responseBody = serializeToJson(response);
+        String responseBody = serializeToJson(response.getBody());
         log.info(RESPONSE_LOG_TEMPLATE,
                 request.getMethod(),
                 response.getStatusCode(),
@@ -58,12 +58,10 @@ public class HttpLoggingAspect {
             pointcut = "@within(org.springframework.web.bind.annotation.RestControllerAdvice))",
             returning = "result"
     )
-    public Object logRequestAndResponseForExceptionHandler(
-            Object result
-    ) {
+    public Object logRequestAndResponseForExceptionHandler(Object result) {
         HttpServletRequest httpRequest = getCurrentHttpRequest();
         ResponseEntity<?> response = (ResponseEntity<?>) result;
-        String responseBody = serializeToJson(response);
+        String responseBody = serializeToJson(response.getBody());
         log.warn(EXCEPTION_RESPONSE_LOG_TEMPLATE,
                 httpRequest.getMethod(),
                 response.getStatusCode(),
@@ -78,9 +76,7 @@ public class HttpLoggingAspect {
                     "|| within(com.example.ratesservice.client.rides.RidesClient+))",
             returning = "result"
     )
-    public Object logFeignClientRequest(
-            Object result
-    ) {
+    public Object logFeignClientRequest(Object result) {
         String responseBody = serializeToJson(result);
         log.info(FEIGN_CLIENT_REQUEST_LOG_TEMPLATE,
                 responseBody);

--- a/rates-service/src/main/java/com/example/ratesservice/utility/constants/LogMessagesTemplate.java
+++ b/rates-service/src/main/java/com/example/ratesservice/utility/constants/LogMessagesTemplate.java
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class LogMessagesTemplate {
 
-    public static final String REQUEST_LOG_TEMPLATE = "Http-{} request | URI: {} | Request args: {}";
+    public static final String REQUEST_LOG_TEMPLATE = "Http-{} request | URI: {} | Request body: {}";
     public static final String RESPONSE_LOG_TEMPLATE =
-            "Http-{} response | Status code: {} | URI: {} | Response args: {} | Duration: {} ms";
+            "Http-{} response | Status code: {} | URI: {} | Response body: {} | Duration: {} ms";
     public static final String EXCEPTION_RESPONSE_LOG_TEMPLATE =
-            "Http-{} exception response | Status code: {} | URI: {} | Response args: {}";
+            "Http-{} exception response | Status code: {} | URI: {} | Response body: {}";
     public static final String FEIGN_CLIENT_REQUEST_LOG_TEMPLATE = "FeignClient request | Request: {}";
     public static final String EVENT_PLACED_LOG_TEMPLATE = "Event placed to EventQueue [{}] | Event: {}";
     public static final String EVENT_EXTRACTED_LOG_TEMPLATE = "Event extracted from EventQueue [{}] | Event: {}";

--- a/rides-service/src/main/java/com/example/ridesservice/configuration/aspect/HttpLoggingAspect.java
+++ b/rides-service/src/main/java/com/example/ridesservice/configuration/aspect/HttpLoggingAspect.java
@@ -44,7 +44,7 @@ public class HttpLoggingAspect {
         ResponseEntity<?> response = (ResponseEntity<?>) joinPoint.proceed();
         long duration = System.currentTimeMillis() - startTime;
 
-        String responseBody = serializeToJson(response);
+        String responseBody = serializeToJson(response.getBody());
         log.info(RESPONSE_LOG_TEMPLATE,
                 request.getMethod(),
                 response.getStatusCode(),
@@ -58,12 +58,10 @@ public class HttpLoggingAspect {
             pointcut = "@within(org.springframework.web.bind.annotation.RestControllerAdvice))",
             returning = "result"
     )
-    public Object logRequestAndResponseForExceptionHandler(
-            Object result
-    ) {
+    public Object logRequestAndResponseForExceptionHandler(Object result) {
         HttpServletRequest httpRequest = getCurrentHttpRequest();
         ResponseEntity<?> response = (ResponseEntity<?>) result;
-        String responseBody = serializeToJson(response);
+        String responseBody = serializeToJson(response.getBody());
         log.warn(EXCEPTION_RESPONSE_LOG_TEMPLATE,
                 httpRequest.getMethod(),
                 response.getStatusCode(),
@@ -77,9 +75,7 @@ public class HttpLoggingAspect {
                     "|| within(com.example.ridesservice.client.passenger.PassengerClient+))",
             returning = "result"
     )
-    public Object logFeignClientRequest(
-            Object result
-    ) {
+    public Object logFeignClientRequest(Object result) {
         String responseBody = serializeToJson(result);
         log.info(FEIGN_CLIENT_RESPONSE_LOG_TEMPLATE, responseBody);
         return result;

--- a/rides-service/src/main/java/com/example/ridesservice/utility/constants/LogMessagesTemplate.java
+++ b/rides-service/src/main/java/com/example/ridesservice/utility/constants/LogMessagesTemplate.java
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class LogMessagesTemplate {
 
-    public static final String REQUEST_LOG_TEMPLATE = "Http-{} request | URI: {} | Request args: {}";
+    public static final String REQUEST_LOG_TEMPLATE = "Http-{} request | URI: {} | Request body: {}";
     public static final String RESPONSE_LOG_TEMPLATE =
-            "Http-{} response | Status code: {} | URI: {} | Response args: {} | Duration: {} ms";
+            "Http-{} response | Status code: {} | URI: {} | Response body: {} | Duration: {} ms";
     public static final String EXCEPTION_RESPONSE_LOG_TEMPLATE =
-            "Http-{} exception response | Status code: {} | URI: {} | Response args: {}";
+            "Http-{} exception response | Status code: {} | URI: {} | Response body: {}";
     public static final String FEIGN_CLIENT_RESPONSE_LOG_TEMPLATE = "FeignClient response | Response: {}";
     public static final String RIDE_PLACED_LOG_TEMPLATE = "Ride placed to RideQueue | QueueRide: {}";
     public static final String RIDE_EXTRACTED_LOG_TEMPLATE = "Ride extracted from RideQueue | QueueRide: {}";


### PR DESCRIPTION
[другой PR] Auth-service, Keycloak service, 3 roles (admin, passenger, driver), user and peron (passenger/driver) have the same UUID => автоматически после создания user создается и person с тем же uuid (из-за этого много изменений связанных со сменой типа id). После /login тебе выдается access и refresh-токены, через 5 минут access истекает и тогда можно через точку /refresh получить новую пару токенов.

Авторизация происходит на gateway (там же стоят все ограничения по доступу к endpoint-ам) + в запрос устанавливается заголовок с uuid пользователя, который делает запрос, чтобы потом произвести проверку на стороне сервиса (passenger/driver), что данный пользователь пытается получить доступ к своим данным (через аспекты).